### PR TITLE
Added bullet point support.

### DIFF
--- a/meta/template.latex
+++ b/meta/template.latex
@@ -52,6 +52,9 @@ $endif$
   \usepackage[T1]{fontenc}
   \usepackage[utf8]{inputenc}
 
+\providecommand{\tightlist}{%
+  \setlength{\itemsep}{0pt}\setlength{\parskip}{0pt}}
+
 $if(euro)$
   \usepackage{eurosym}
 $endif$


### PR DESCRIPTION
This is pulled from the stock pandoc template. I assume you had `\tightlist` defined elsewhere