### PR TITLE
Bullet point support, fixed build

### DIFF
--- a/meta/template.latex
+++ b/meta/template.latex
@@ -51,6 +51,10 @@ $endif$
   \usepackage[T1]{fontenc}
   \usepackage[utf8]{inputenc}
 
+\providecommand{\tightlist}{%
+  \setlength{\itemsep}{0pt}\setlength{\parskip}{0pt}}
+
+
 $if(euro)$
   \usepackage{eurosym}
 $endif$

--- a/meta/template.latex
+++ b/meta/template.latex
@@ -7,7 +7,6 @@ $endif$
 
 \renewcommand{\familydefault}{\sfdefault}
 
-\usepackage{inconsolata}
 \usepackage{color}
 \usepackage{listings}
 \lstset{ %

--- a/meta/template.latex
+++ b/meta/template.latex
@@ -7,7 +7,7 @@ $endif$
 
 \renewcommand{\familydefault}{\sfdefault}
 
-\usepackage{inconsolata}
+% \usepackage{inconsolata}
 \usepackage{color}
 \usepackage{listings}
 \lstset{ %


### PR DESCRIPTION
Build was failing because the template depended on inconsolata.sty, which wasn't included, and shouldn't have been in the repo. Also added bullet point support, which was necessary on my system, at least.